### PR TITLE
Display books as image tiles

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,9 +11,27 @@ users = {
 }
 
 books = [
-    {"id": 1, "title": "1984", "author": "George Orwell", "price": 9.99},
-    {"id": 2, "title": "To Kill a Mockingbird", "author": "Harper Lee", "price": 12.99},
-    {"id": 3, "title": "The Great Gatsby", "author": "F. Scott Fitzgerald", "price": 10.50},
+    {
+        "id": 1,
+        "title": "1984",
+        "author": "George Orwell",
+        "price": 9.99,
+        "image": "https://covers.openlibrary.org/b/isbn/0451524934-L.jpg",
+    },
+    {
+        "id": 2,
+        "title": "To Kill a Mockingbird",
+        "author": "Harper Lee",
+        "price": 12.99,
+        "image": "https://covers.openlibrary.org/b/isbn/9780061120084-L.jpg",
+    },
+    {
+        "id": 3,
+        "title": "The Great Gatsby",
+        "author": "F. Scott Fitzgerald",
+        "price": 10.50,
+        "image": "https://covers.openlibrary.org/b/isbn/9780743273565-L.jpg",
+    },
 ]
 
 

--- a/templates/books.html
+++ b/templates/books.html
@@ -16,16 +16,22 @@
 </nav>
 <div class="container mt-4">
     <h1 class="mb-4">Available Books</h1>
-    <ul class="list-group">
+    <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 g-4">
         {% for book in books %}
-        <li class="list-group-item d-flex justify-content-between align-items-center">
-            <span>{{ book.title }} by {{ book.author }} - ${{ '%.2f'|format(book.price) }}</span>
-            <form action="{{ url_for('add_to_cart', book_id=book.id) }}" method="post" class="m-0">
-                <button type="submit" class="btn btn-sm btn-primary">Add to cart</button>
-            </form>
-        </li>
+        <div class="col">
+            <div class="card h-100">
+                <img src="{{ book.image }}" class="card-img-top" alt="Cover of {{ book.title }}">
+                <div class="card-body d-flex flex-column">
+                    <h5 class="card-title">{{ book.title }}</h5>
+                    <p class="card-text">{{ book.author }} - ${{ '%.2f'|format(book.price) }}</p>
+                    <form action="{{ url_for('add_to_cart', book_id=book.id) }}" method="post" class="mt-auto">
+                        <button type="submit" class="btn btn-sm btn-primary">Add to cart</button>
+                    </form>
+                </div>
+            </div>
+        </div>
         {% endfor %}
-    </ul>
+    </div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show each book as a card with cover image
- add cover image URLs to in-memory book data

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a5bb5f245083228bba948ed5c58c39