### PR TITLE
feat: shrink book tiles

### DIFF
--- a/templates/books.html
+++ b/templates/books.html
@@ -16,7 +16,7 @@
 </nav>
 <div class="container mt-4">
     <h1 class="mb-4">Available Books</h1>
-    <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 g-4">
+    <div class="row row-cols-2 row-cols-sm-4 row-cols-md-6 g-4">
         {% for book in books %}
         <div class="col">
             <div class="card h-100">


### PR DESCRIPTION
## Summary
- Make book tiles 50% smaller by doubling grid columns in books view

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5bcf996d083229d88a3be7f63c609