### PR TITLE
Add quantity controls and author info to cart

### DIFF
--- a/templates/cart.html
+++ b/templates/cart.html
@@ -22,8 +22,28 @@
             <ul class="list-group mb-3">
             {% for item in cart %}
                 <li class="list-group-item d-flex justify-content-between align-items-center">
-                    <span>{{ item.title }}</span>
-                    <span>${{ '%.2f'|format(item.price) }}</span>
+                    <div>
+                        <span>{{ item.author }} - {{ item.title }}</span>
+                        <span class="ms-2 text-muted">${{ '%.2f'|format(item.price) }} each</span>
+                    </div>
+                    <div class="d-flex align-items-center">
+                        <form action="{{ url_for('update_cart', book_id=item.id, action='decrease') }}"
+                              method="post"
+                              class="me-2">
+                            <button class="btn btn-sm btn-outline-secondary" type="submit">-</button>
+                        </form>
+                        <span>{{ item.quantity }}</span>
+                        <form action="{{ url_for('update_cart', book_id=item.id, action='increase') }}"
+                              method="post"
+                              class="ms-2">
+                            <button class="btn btn-sm btn-outline-secondary" type="submit">+</button>
+                        </form>
+                        <form action="{{ url_for('update_cart', book_id=item.id, action='remove') }}"
+                              method="post"
+                              class="ms-3">
+                            <button class="btn btn-sm btn-outline-danger" type="submit">Remove</button>
+                        </form>
+                    </div>
                 </li>
             {% endfor %}
             </ul>


### PR DESCRIPTION
## Summary
- Track quantities in cart and allow per-item increment, decrement, and removal actions
- Display book author alongside title within the cart and compute totals with quantities

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5bea54c5083229c626b7c8345de72