### PR TITLE
Simulate failure for Observability Engineering orders

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 from functools import wraps
+import time
 from flask import Flask, render_template, request, redirect, url_for, session
 
 app = Flask(__name__)
@@ -166,10 +167,22 @@ def update_cart(book_id, action):
 def view_cart():
     cart = session.setdefault("cart", [])
     if request.method == "POST":
+        if any(item["title"] == "Observability Engineering" for item in cart):
+            time.sleep(10)
+            total = sum(item["price"] * item["quantity"] for item in cart)
+            return render_template(
+                "cart.html",
+                cart=cart,
+                total=total,
+                message=None,
+                error="Ups, something went wrong",
+            )
         session["cart"] = []
-        return render_template("cart.html", cart=[], total=0, message="Order placed successfully!")
+        return render_template(
+            "cart.html", cart=[], total=0, message="Order placed successfully!", error=None
+        )
     total = sum(item["price"] * item["quantity"] for item in cart)
-    return render_template("cart.html", cart=cart, total=total, message=None)
+    return render_template("cart.html", cart=cart, total=total, message=None, error=None)
 
 
 if __name__ == "__main__":

--- a/templates/cart.html
+++ b/templates/cart.html
@@ -17,6 +17,8 @@
     <h1 class="mb-4">Your Cart</h1>
     {% if message %}
         <div class="alert alert-success" role="alert">{{ message }}</div>
+    {% elif error %}
+        <div class="alert alert-danger" role="alert">{{ error }}</div>
     {% else %}
         {% if cart %}
             <ul class="list-group mb-3">


### PR DESCRIPTION
## Summary
- Delay order finalization by 10 seconds when "Observability Engineering" is in the cart and return error
- Display error alert on the cart page

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5c38191e083229a6461606a0117ce