### PR TITLE
Add post-order feedback options

### DIFF
--- a/app.py
+++ b/app.py
@@ -176,13 +176,49 @@ def view_cart():
                 total=total,
                 message=None,
                 error="Ups, something went wrong",
+                feedback_submitted=False,
             )
         session["cart"] = []
         return render_template(
-            "cart.html", cart=[], total=0, message="Order placed successfully!", error=None
+            "cart.html",
+            cart=[],
+            total=0,
+            message="Order placed successfully!",
+            error=None,
+            feedback_submitted=False,
         )
     total = sum(item["price"] * item["quantity"] for item in cart)
-    return render_template("cart.html", cart=cart, total=total, message=None, error=None)
+    return render_template(
+        "cart.html", cart=cart, total=total, message=None, error=None, feedback_submitted=False
+    )
+
+
+@app.post("/rate")
+@login_required
+def rate():
+    rating = int(request.form.get("rating", 0))
+    session.setdefault("ratings", []).append(rating)
+    return render_template(
+        "cart.html",
+        cart=[],
+        total=0,
+        message="Thank you for your feedback!",
+        error=None,
+        feedback_submitted=True,
+    )
+
+
+@app.route("/report", methods=["GET", "POST"])
+@login_required
+def report():
+    submitted = False
+    if request.method == "POST":
+        description = request.form.get("description")
+        session.setdefault("reports", []).append(
+            {"user": session.get("username"), "description": description}
+        )
+        submitted = True
+    return render_template("report.html", submitted=submitted)
 
 
 if __name__ == "__main__":

--- a/templates/cart.html
+++ b/templates/cart.html
@@ -5,6 +5,25 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Your Cart</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <style>
+        .rating {
+            direction: rtl;
+            unicode-bidi: bidi-override;
+            font-size: 2rem;
+        }
+        .rating input {
+            display: none;
+        }
+        .rating label {
+            color: #ddd;
+            cursor: pointer;
+        }
+        .rating input:checked ~ label,
+        .rating label:hover,
+        .rating label:hover ~ label {
+            color: #f5c518;
+        }
+    </style>
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
@@ -19,6 +38,29 @@
         <div class="alert alert-success" role="alert">{{ message }}</div>
     {% elif error %}
         <div class="alert alert-danger" role="alert">{{ error }}</div>
+    {% endif %}
+    {% if message or error %}
+        {% if not feedback_submitted %}
+        <div class="mt-4">
+            <h5>Rate your experience:</h5>
+            <form action="{{ url_for('rate') }}" method="post">
+                <div class="rating">
+                    <input type="radio" id="star5" name="rating" value="5" required>
+                    <label for="star5">★</label>
+                    <input type="radio" id="star4" name="rating" value="4">
+                    <label for="star4">★</label>
+                    <input type="radio" id="star3" name="rating" value="3">
+                    <label for="star3">★</label>
+                    <input type="radio" id="star2" name="rating" value="2">
+                    <label for="star2">★</label>
+                    <input type="radio" id="star1" name="rating" value="1">
+                    <label for="star1">★</label>
+                </div>
+                <button type="submit" class="btn btn-primary mt-2">Submit Rating</button>
+            </form>
+        </div>
+        {% endif %}
+        <a href="{{ url_for('report') }}" class="btn btn-link mt-3">Report a problem</a>
     {% else %}
         {% if cart %}
             <ul class="list-group mb-3">

--- a/templates/report.html
+++ b/templates/report.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Report a Problem</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body>
+<nav class="navbar navbar-light bg-light">
+    <div class="container-fluid">
+        <a class="btn btn-outline-primary" href="{{ url_for('view_cart') }}">Back to Cart</a>
+    </div>
+</nav>
+<div class="container mt-4">
+    <h1 class="mb-3">Report a Problem</h1>
+    <p>If you need immediate assistance, contact our support team:</p>
+    <ul>
+        <li>Email: support@example.com</li>
+        <li>Phone: +1-800-555-1234</li>
+    </ul>
+    {% if submitted %}
+        <div class="alert alert-success" role="alert">Report submitted. We'll get back to you soon.</div>
+    {% else %}
+        <form method="post">
+            <div class="mb-3">
+                <label for="description" class="form-label">Describe the issue</label>
+                <textarea class="form-control" id="description" name="description" rows="5" required></textarea>
+            </div>
+            <button type="submit" class="btn btn-primary">Submit Report</button>
+        </form>
+    {% endif %}
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow customers to rate their experience after placing an order
- provide link to report a problem with contact details and submission form

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5c6c362e08322a1220c4873a1fdca