### PR TITLE
Rename finalize order action to checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Conference 2025 Bookstore
 
-This is a very simple Flask-based bookstore demo. Users can log in, browse a list of books, add them to a cart and finalize an order. The application is designed for demonstration purposes only and uses in-memory data structures instead of a database.
+This is a very simple Flask-based bookstore demo. Users can log in, browse a list of books, add them to a cart and checkout. The application is designed for demonstration purposes only and uses in-memory data structures instead of a database.
 
 ## Running locally
 

--- a/templates/cart.html
+++ b/templates/cart.html
@@ -108,7 +108,7 @@
             </ul>
             <p class="fw-bold">Total: ${{ '%.2f'|format(total) }}</p>
             <form method="post" onsubmit="showLoading()">
-                <button id="finalizeButton" type="submit" class="btn btn-success">Finalize Order</button>
+                <button id="checkoutButton" type="submit" class="btn btn-success">Checkout</button>
                 <div id="loadingSpinner" class="spinner-border text-success ms-2" role="status" style="display: none;">
                     <span class="visually-hidden">Loading...</span>
                 </div>
@@ -120,7 +120,7 @@
 </div>
 <script>
     function showLoading() {
-        document.getElementById('finalizeButton').style.display = 'none';
+        document.getElementById('checkoutButton').style.display = 'none';
         document.getElementById('loadingSpinner').style.display = 'inline-block';
     }
 </script>


### PR DESCRIPTION
## Summary
- Rename cart's finalize button to checkout
- Update README to match new checkout terminology

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b83d097f288322aac4fe0a2e318c4e